### PR TITLE
feat(.gitignore): add more venv name possibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,11 +102,11 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
-.venv
-env/
-venv/
-ENV/
+.env*
+.venv*
+env*/
+venv*/
+ENV*/
 env.bak/
 venv.bak/
 


### PR DESCRIPTION
Just testing the behavior of an open PR when we rename `master` to `main`.